### PR TITLE
Stop native keyboard from pushing up screen content

### DIFF
--- a/login-workflow/example/android/app/src/main/AndroidManifest.xml
+++ b/login-workflow/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustPan">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #13.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update AndroidManifest android:windowSoftInputMode to 'adjustPan' to stop keyboard from pushing screen content up.