### PR TITLE
Fix crash on iOS

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.0.1
+
+### Fixed
+-   Issue causing application to crash when existing user completes self-registration flow ([#50](https://github.com/pxblue/react-native-workflows/issues/50)).
+
 ## v3.0.0
 
 ### Added

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -497,7 +497,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: a28897a626e417fac264bb26dd72ad0e9af5bfa8
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: 5c33578afe8c682301000286972a91e943d998e2
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
@@ -507,10 +507,10 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 19d4e11abe55266cf98e1e24f94a850a44fdec35
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  RCT-Folly: fa983ee666a7087ebbb1489b453d69cac3581786
+  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pxblue/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "license": "BSD-3-Clause",
     "author": {
         "name": "PX Blue",

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -364,12 +364,12 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
     useEffect(() => {
         if (viewPager && viewPager.current) {
             if (currentPage === CompletePage) {
-                viewPager.current.setPageWithoutAnimation(currentPage);
+                requestAnimationFrame(() => viewPager.current?.setPageWithoutAnimation(currentPage));
             } else {
-                viewPager.current.setPage(currentPage);
+                requestAnimationFrame(() => viewPager.current?.setPage(currentPage));
             }
         }
-    }, [currentPage, viewPager, registrationSuccess, CompletePage]);
+    }, [currentPage, viewPager, CompletePage]);
 
     const errorDialog = (
         <SimpleDialog

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -454,14 +454,12 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     // View pager
     useEffect(() => {
         if (currentPage === CompletePage) {
-            // eslint-disable-next-line no-unused-expressions
-            viewPager?.current?.setPageWithoutAnimation(currentPage);
+            requestAnimationFrame(() => viewPager.current?.setPageWithoutAnimation(currentPage));
         } else {
-            // eslint-disable-next-line no-unused-expressions
-            viewPager?.current?.setPage(currentPage);
+            requestAnimationFrame(() => viewPager.current?.setPage(currentPage));
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [currentPage, viewPager, registrationSuccess]);
+    }, [currentPage, viewPager]);
 
     // Network state (loading eula)
     const errorBodyText =


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #50.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use request animation frame to avoid crashing when completing self registration flow for an existing user

> I did not verify this on android, so if somebody could run through the four scenarios (invite-accountExists, invite-accountDoesNotExist, self-accountExists, self-accountDoesNotExist) to make sure they work, that would be great.