### PR TITLE
Fix issue with html eula and keyboard blocking input

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.2.2 (Unpublished)
+
+### Fixed
+
+-   Issue with html EULA screen not appearing ([#86](https://github.com/pxblue/react-native-workflows/issues/86)).
+-   Issue with soft keyboard blocking input field ([#84](https://github.com/pxblue/react-native-workflows/issues/84)).
+
+
 ## v3.2.1 (June 30, 2021)
 
 ### Fixed

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.2.2 (Unpublished)
+## v3.2.2 (July 15, 2020)
 
 ### Fixed
 

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pxblue/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "license": "BSD-3-Clause",
     "author": {
         "name": "PX Blue",

--- a/login-workflow/src/subScreens/Eula.tsx
+++ b/login-workflow/src/subScreens/Eula.tsx
@@ -100,9 +100,9 @@ export const Eula: React.FC<EulaProps> = (props) => {
     };
 
     return (
-        <SafeAreaView style={containerStyles.safeContainer}>
+        <SafeAreaView style={[containerStyles.safeContainer]}>
             <View style={[containerStyles.mainContainer, containerStyles.containerMargins]}>
-                <View style={{ maxWidth: 600 }}>
+                <View style={{ flex: 1, maxWidth: 600 }}>
                     {htmlEula ? (
                         <WebView
                             originWhitelist={['*']}

--- a/login-workflow/src/subScreens/ResetPassword.tsx
+++ b/login-workflow/src/subScreens/ResetPassword.tsx
@@ -160,7 +160,7 @@ export const ResetPassword: React.FC<ResetPasswordProps> = (props) => {
                     <TextInput
                         label={t('pxb:LABELS.EMAIL')}
                         value={emailInput}
-                        style={[styles.inputMargin, { marginTop: 150 }]}
+                        style={[styles.inputMargin]}
                         keyboardType={'email-address'}
                         autoCapitalize={'none'}
                         onChangeText={(text: string): void => {

--- a/login-workflow/src/subScreens/ResetPassword.tsx
+++ b/login-workflow/src/subScreens/ResetPassword.tsx
@@ -43,12 +43,16 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme, insets: any): Record
             marginTop: 8,
             flex: 1,
         },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
+        },
         containerMargins: {
             marginHorizontal: 16,
-        },
-        spaceBetween: {
-            flex: 1,
-            justifyContent: 'space-between',
         },
     });
 
@@ -143,41 +147,39 @@ export const ResetPassword: React.FC<ResetPasswordProps> = (props) => {
         <SafeAreaView style={containerStyles.safeContainer}>
             {spinner}
             {errorDialog}
-            <KeyboardAwareScrollView style={{ flex: 1 }} contentContainerStyle={containerStyles.spaceBetween}>
-                <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'center' }}>
-                    <View style={{ maxWidth: 600 }}>
-                        <Instruction
-                            text={t('pxb:FORGOT_PASSWORD.INSTRUCTIONS', { replace: { phone: contactPhone } })}
-                            style={containerStyles.containerMargins}
-                        />
+            <KeyboardAwareScrollView
+                style={containerStyles.scrollContainer}
+                contentContainerStyle={[containerStyles.scrollContentContainer]}
+            >
+                <Instruction
+                    text={t('pxb:FORGOT_PASSWORD.INSTRUCTIONS', { replace: { phone: contactPhone } })}
+                    style={containerStyles.containerMargins}
+                />
 
-                        <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
-                            <TextInput
-                                label={t('pxb:LABELS.EMAIL')}
-                                value={emailInput}
-                                style={styles.inputMargin}
-                                keyboardType={'email-address'}
-                                autoCapitalize={'none'}
-                                onChangeText={(text: string): void => {
-                                    setEmailInput(text);
-                                    setHasEmailFormatError(false);
-                                }}
-                                error={hasTransitError || hasEmailFormatError}
-                                errorText={
-                                    hasTransitError
-                                        ? t('pxb:LOGIN.INCORRECT_CREDENTIALS')
-                                        : hasEmailFormatError
-                                        ? t('pxb:MESSAGES.EMAIL_ENTRY_ERROR')
-                                        : ''
-                                }
-                                onBlur={(): void => {
-                                    if (emailInput.length > 0 && !EMAIL_REGEX.test(emailInput))
-                                        setHasEmailFormatError(true);
-                                }}
-                                onSubmitEditing={isValidEmail ? onResetPasswordTap : undefined}
-                            />
-                        </View>
-                    </View>
+                <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
+                    <TextInput
+                        label={t('pxb:LABELS.EMAIL')}
+                        value={emailInput}
+                        style={[styles.inputMargin, { marginTop: 150 }]}
+                        keyboardType={'email-address'}
+                        autoCapitalize={'none'}
+                        onChangeText={(text: string): void => {
+                            setEmailInput(text);
+                            setHasEmailFormatError(false);
+                        }}
+                        error={hasTransitError || hasEmailFormatError}
+                        errorText={
+                            hasTransitError
+                                ? t('pxb:LOGIN.INCORRECT_CREDENTIALS')
+                                : hasEmailFormatError
+                                ? t('pxb:MESSAGES.EMAIL_ENTRY_ERROR')
+                                : ''
+                        }
+                        onBlur={(): void => {
+                            if (emailInput.length > 0 && !EMAIL_REGEX.test(emailInput)) setHasEmailFormatError(true);
+                        }}
+                        onSubmitEditing={isValidEmail ? onResetPasswordTap : undefined}
+                    />
                 </View>
             </KeyboardAwareScrollView>
             <View style={[styles.wideButton, containerStyles.containerMargins]}>

--- a/login-workflow/src/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/subScreens/VerifyEmail.tsx
@@ -29,6 +29,14 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             flexDirection: 'row',
             justifyContent: 'center',
         },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
+        },
         mainContainer: {
             marginTop: 8,
             flex: 1,
@@ -95,36 +103,37 @@ export const VerifyEmail: React.FC<VerifyEmailProps> = (props) => {
 
     return (
         <SafeAreaView style={containerStyles.safeContainer}>
-            <View style={{ width: '100%', maxWidth: 600 }}>
-                <KeyboardAwareScrollView>
-                    <Instruction
-                        style={containerStyles.containerMargins}
-                        text={t('pxb:SELF_REGISTRATION.VERIFY_EMAIL.MESSAGE')}
-                    />
+            <KeyboardAwareScrollView
+                style={containerStyles.scrollContainer}
+                contentContainerStyle={containerStyles.scrollContentContainer}
+            >
+                <Instruction
+                    style={containerStyles.containerMargins}
+                    text={t('pxb:SELF_REGISTRATION.VERIFY_EMAIL.MESSAGE')}
+                />
 
-                    <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
-                        <TextInput
-                            label={t('pxb:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION')}
-                            value={verifyCode}
+                <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
+                    <TextInput
+                        label={t('pxb:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION')}
+                        value={verifyCode}
+                        style={styles.inputMargin}
+                        keyboardType={'default'}
+                        autoCapitalize={'none'}
+                        onChangeText={setVerifyCode}
+                        onSubmitEditing={verifyCode.length ? props.onSubmit : undefined}
+                    />
+                    <View style={{ flex: 1 }}>
+                        <Button
+                            uppercase={false}
+                            mode={'contained'}
+                            onPress={(): void => onResendVerificationEmail()}
                             style={styles.inputMargin}
-                            keyboardType={'default'}
-                            autoCapitalize={'none'}
-                            onChangeText={setVerifyCode}
-                            onSubmitEditing={verifyCode.length ? props.onSubmit : undefined}
-                        />
-                        <View style={{ flex: 1 }}>
-                            <Button
-                                uppercase={false}
-                                mode={'contained'}
-                                onPress={(): void => onResendVerificationEmail()}
-                                style={styles.inputMargin}
-                            >
-                                {t('pxb:SELF_REGISTRATION.VERIFY_EMAIL.RESEND')}
-                            </Button>
-                        </View>
+                        >
+                            {t('pxb:SELF_REGISTRATION.VERIFY_EMAIL.RESEND')}
+                        </Button>
                     </View>
-                </KeyboardAwareScrollView>
-            </View>
+                </View>
+            </KeyboardAwareScrollView>
         </SafeAreaView>
     );
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #84 
Fixes #86

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fixes an issue where html EULA content is not displayed during registration (86) 
- Fixes an issue where the software keyboard blocks the input fields on forgot password screen (84)
- Refactors max width behavior on two screens to show how we want to fix 75 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
**Input Issue**
- Run the demo project and go to the forgot password screen
- Trigger the software keyboard and confirm that the page is still scrollable and you can bring the input field into view

**EULA Issue**
- Follow the reproduction steps in the bug (set htmlEula to true and update registrationUIActions to return HTML content for the eula)
- Confirm that the HTML eula is displayed