### PR TITLE
React Native workflow fixes

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.3.0 (Unreleased)
+## v3.3.0 (July 21, 2021)
 
 ### Fixed
 
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
 
-## v3.2.2 (July 15, 2020)
+## v3.2.2 (July 15, 2021)
 
 ### Fixed
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Issue with disabled back button at certain points in the registration workflows.
 -   Issue where "Invalid Credentials" error message would persist on login screen.
 
 ### Changed
 
--   EULA page order in the self registration workflow.
+-   EULA screen now appears first in the self registration workflow.
+-   Allow users to go back at all steps of the registration flow ([#83](https://github.com/pxblue/react-native-workflows/issues/83)).
 
 ### Added
 
--   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
+-   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider` ([#90](https://github.com/pxblue/react-native-workflows/issues/90)).
 
 ## v3.2.2 (July 15, 2021)
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Issue with disabled back button at certain points in the registration workflows.
+-   Issue where "Invalid Credentials" error message would persist on login screen.
 
 ### Changed
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,13 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.3.0 (Unreleased)
+
+### Fixed
+
+-   Issue with disabled back button at certain points in the registration workflows.
+
+### Changed
+
+-   EULA page order in the self registration workflow.
+
+### Added
+
+-   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
+
 ## v3.2.2 (July 15, 2020)
 
 ### Fixed
 
 -   Issue with html EULA screen not appearing ([#86](https://github.com/pxblue/react-native-workflows/issues/86)).
 -   Issue with soft keyboard blocking input field ([#84](https://github.com/pxblue/react-native-workflows/issues/84)).
-
 
 ## v3.2.1 (June 30, 2021)
 

--- a/login-workflow/example/App.tsx
+++ b/login-workflow/example/App.tsx
@@ -80,6 +80,14 @@ export const AuthUIConfiguration: React.FC = (props) => {
                     component: CustomAccountDetailsTwo,
                 },
             ]}
+            // registrationConfig={{
+            //     firstName: {
+            //         maxLength: 30,
+            //     },
+            //     lastName: {
+            //         maxLength: 30,
+            //     },
+            // }}
             // showCybersecurityBadge={false}
             // showContactSupport={false}
             // showRememberMe={false}

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -500,7 +500,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 5c33578afe8c682301000286972a91e943d998e2
+  FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489

--- a/login-workflow/example/ios/example/AppDelegate.m
+++ b/login-workflow/example/ios/example/AppDelegate.m
@@ -4,6 +4,10 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 
+#if RCT_DEV
+#import <React/RCTDevLoadingView.h>
+#endif
+
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
 #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -49,7 +49,7 @@
         "tag-package": "npx -p @pxblue/tag pxb-tag"
     },
     "dependencies": {
-        "@pxblue/react-auth-shared": "^3.2.0",
+        "@pxblue/react-auth-shared": "^3.4.0",
         "lodash.clonedeep": "^4.5.0",
         "react-native-status-bar-height": "^2.5.0"
     },

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pxblue/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "PX Blue",

--- a/login-workflow/src/__tests__/subscreens/AccountDetails-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/AccountDetails-test.tsx
@@ -12,6 +12,21 @@ import renderer from 'react-test-renderer';
 import { AccountDetails, AccountDetailInformation } from '../../subScreens/AccountDetails';
 import { TextInputHTMLAttributes } from '@pxblue/react-auth-shared';
 
+jest.mock('@pxblue/react-auth-shared', () => ({
+    ...jest.requireActual('@pxblue/react-auth-shared'),
+    useAuthUIActions: (): any => ({ dispatch: jest.fn(() => true) }),
+    useInjectedUIContext: jest.fn().mockReturnValue({
+        registrationConfig: {
+            firstName: {
+                maxLength: 30,
+            },
+            lastName: {
+                maxLength: 30,
+            },
+        },
+    }),
+}));
+
 describe('AccountDetails subScreen tested with enzyme', () => {
     const act = renderer.act;
 

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -212,7 +212,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                 />
             ),
             canGoForward: eulaAccepted,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'CreatePassword',

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -522,7 +522,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                     activeColor={theme.colors.primaryBase || theme.colors.primary}
                     leftButton={
                         <ToggleButton
-                            text={t('pxb:ACTIONS.BACK')}
+                            text={isFirstStep ? t('pxb:ACTIONS.CANCEL') : t('pxb:ACTIONS.BACK')}
                             style={{ width: 100, alignSelf: 'flex-start' }}
                             outlined={true}
                             disabled={!canGoBackProgress()}

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -49,7 +49,7 @@ import {
 } from '@pxblue/react-auth-shared';
 import { CustomRegistrationDetailsGroup, RegistrationPage } from '../types';
 import { Instruction } from '../components/Instruction';
-import { MobileStepper } from '@pxblue/react-native-components';
+import { MobileStepper, Spacer } from '@pxblue/react-native-components';
 import Color from 'color';
 
 /**
@@ -521,13 +521,17 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                     activeStep={currentPage}
                     activeColor={theme.colors.primaryBase || theme.colors.primary}
                     leftButton={
-                        <ToggleButton
-                            text={isFirstStep ? t('pxb:ACTIONS.CANCEL') : t('pxb:ACTIONS.BACK')}
-                            style={{ width: 100, alignSelf: 'flex-start' }}
-                            outlined={true}
-                            disabled={!canGoBackProgress()}
-                            onPress={(): void => advancePage(-1)}
-                        />
+                        isFirstStep ? (
+                            <Spacer flex={0} width={100} />
+                        ) : (
+                            <ToggleButton
+                                text={t('pxb:ACTIONS.BACK')}
+                                style={{ width: 100, alignSelf: 'flex-start' }}
+                                outlined={true}
+                                disabled={!canGoBackProgress()}
+                                onPress={(): void => advancePage(-1)}
+                            />
+                        )
                     }
                     rightButton={
                         <ToggleButton

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -38,6 +38,7 @@ import {
     useAccountUIState,
     useInjectedUIContext,
     useSecurityState,
+    AccountActions,
 } from '@pxblue/react-auth-shared';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -349,7 +350,8 @@ export const Login: React.FC<LoginProps> = (props) => {
                             onChangeText={(text: string): void => {
                                 setEmailInput(text);
                                 setHasEmailFormatError(false);
-                                authUIState.login.transitErrorMessage = null;
+                                if (authUIState.login.transitErrorMessage !== null)
+                                    authUIActions.dispatch(AccountActions.resetLogin());
                             }}
                             onSubmitEditing={(): void => {
                                 goToNextInput();
@@ -377,7 +379,8 @@ export const Login: React.FC<LoginProps> = (props) => {
                             autoCapitalize={'none'}
                             onChangeText={(text: string): void => {
                                 setPasswordInput(text);
-                                authUIState.login.transitErrorMessage = null;
+                                if (authUIState.login.transitErrorMessage !== null)
+                                    authUIActions.dispatch(AccountActions.resetLogin());
                             }}
                             returnKeyType={'done'}
                             style={{ marginTop: 44 }}

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -349,6 +349,7 @@ export const Login: React.FC<LoginProps> = (props) => {
                             onChangeText={(text: string): void => {
                                 setEmailInput(text);
                                 setHasEmailFormatError(false);
+                                authUIState.login.transitErrorMessage = null;
                             }}
                             onSubmitEditing={(): void => {
                                 goToNextInput();
@@ -374,7 +375,10 @@ export const Login: React.FC<LoginProps> = (props) => {
                             label={t('pxb:LABELS.PASSWORD')}
                             value={passwordInput}
                             autoCapitalize={'none'}
-                            onChangeText={(text: string): void => setPasswordInput(text)}
+                            onChangeText={(text: string): void => {
+                                setPasswordInput(text);
+                                authUIState.login.transitErrorMessage = null;
+                            }}
                             returnKeyType={'done'}
                             style={{ marginTop: 44 }}
                             error={isInvalidCredentials}

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -237,20 +237,6 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
         customDetails.length > 0 && customDetails[0] ? customDetails[0].component : null;
     const RegistrationPages: RegistrationPage[] = [
         {
-            name: 'CreateAccount',
-            pageTitle: t('pxb:REGISTRATION.STEPS.CREATE_ACCOUNT'),
-            pageBody: (
-                <CreateAccountScreen
-                    key={'CreateAccountPage'}
-                    onEmailChanged={setEmail}
-                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                    onSubmit={(): void => advancePage(1)}
-                />
-            ),
-            canGoForward: email.length > 0,
-            canGoBack: true,
-        },
-        {
             name: 'Eula',
             pageTitle: t('pxb:REGISTRATION.STEPS.LICENSE'),
             pageBody: (
@@ -268,6 +254,20 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                 </View>
             ),
             canGoForward: eulaAccepted,
+            canGoBack: true,
+        },
+        {
+            name: 'CreateAccount',
+            pageTitle: t('pxb:REGISTRATION.STEPS.CREATE_ACCOUNT'),
+            pageBody: (
+                <CreateAccountScreen
+                    key={'CreateAccountPage'}
+                    onEmailChanged={setEmail}
+                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                    onSubmit={(): void => advancePage(1)}
+                />
+            ),
+            canGoForward: email.length > 0,
             canGoBack: true,
         },
         {

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -33,7 +33,7 @@ import { Spinner } from '../components/Spinner';
 import { SimpleDialog } from '../components/SimpleDialog';
 import { ToggleButton } from '../components/ToggleButton';
 import i18n from '../translations/i18n';
-import { MobileStepper } from '@pxblue/react-native-components';
+import { MobileStepper, Spacer } from '@pxblue/react-native-components';
 
 // Styles
 import * as Colors from '@pxblue/colors';
@@ -634,13 +634,17 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     activeStep={currentPage}
                     activeColor={theme.colors.primaryBase || theme.colors.primary}
                     leftButton={
-                        <ToggleButton
-                            text={t('pxb:ACTIONS.BACK')}
-                            style={{ width: 100, alignSelf: 'flex-start' }}
-                            outlined={true}
-                            disabled={!canGoBackProgress()}
-                            onPress={(): void => advancePage(-1)}
-                        />
+                        isFirstStep ? (
+                            <Spacer flex={0} width={100} />
+                        ) : (
+                            <ToggleButton
+                                text={t('pxb:ACTIONS.BACK')}
+                                style={{ width: 100, alignSelf: 'flex-start' }}
+                                outlined={true}
+                                disabled={!canGoBackProgress()}
+                                onPress={(): void => advancePage(-1)}
+                            />
+                        )
                     }
                     rightButton={
                         <ToggleButton

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -268,7 +268,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                 </View>
             ),
             canGoForward: eulaAccepted,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'VerifyEmail',
@@ -286,7 +286,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                 />
             ),
             canGoForward: verificationCode.length > 0,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'CreatePassword',
@@ -301,7 +301,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                 </KeyboardAwareScrollView>
             ),
             canGoForward: password.length > 0,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'AccountDetails',

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -414,7 +414,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     const isLastStep = currentPage === RegistrationPages.length - 1;
     const isFirstStep = currentPage === 0;
     const CompletePage = RegistrationPages.length - 1;
-    const EulaPage = RegistrationPages.findIndex((item) => item.name === 'Eula');
+    const CreateAccountPage = RegistrationPages.findIndex((item) => item.name === 'CreateAccount');
     const VerifyEmailPage = RegistrationPages.findIndex((item) => item.name === 'VerifyEmail');
     const CreatePasswordPage = RegistrationPages.findIndex((item) => item.name === 'CreatePassword');
 
@@ -433,7 +433,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     }, [registrationSuccess]);
 
     useEffect(() => {
-        if (currentPage === EulaPage && codeRequestSuccess) {
+        if (currentPage === CreateAccountPage && codeRequestSuccess) {
             setCurrentPage(VerifyEmailPage);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -553,7 +553,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                 ) {
                     void attemptRegistration();
                 } else if (
-                    currentPage === EulaPage &&
+                    currentPage === CreateAccountPage &&
                     !codeRequestIsInTransit &&
                     canProgress() &&
                     (delta as number) > 0
@@ -583,7 +583,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             registrationSuccess,
             requestCode,
             validateCode,
-            EulaPage,
+            CreateAccountPage,
             RegistrationPages.length,
             VerifyEmailPage,
         ]

--- a/login-workflow/src/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/subScreens/AccountDetails.tsx
@@ -13,7 +13,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { useTheme } from 'react-native-paper';
 
 // Hooks
-import { useLanguageLocale } from '@pxblue/react-auth-shared';
+import { useInjectedUIContext, useLanguageLocale } from '@pxblue/react-auth-shared';
 
 /**
  * @ignore
@@ -90,6 +90,9 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
     const [lastNameInput, setLastNameInput] = React.useState('');
     const { t } = useLanguageLocale();
 
+    const firstNameLengthLimit = useInjectedUIContext()?.registrationConfig?.firstName?.maxLength || null;
+    const lastNameLengthLimit = useInjectedUIContext()?.registrationConfig?.lastName?.maxLength || null;
+
     React.useEffect(() => {
         if (firstNameInput.length > 0 && lastNameInput.length > 0) {
             props.onDetailsChanged({ firstName: firstNameInput, lastName: lastNameInput });
@@ -126,6 +129,7 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                                 goToLastName();
                             }}
                             blurOnSubmit={false}
+                            maxLength={firstNameLengthLimit}
                         />
 
                         <TextInput
@@ -139,6 +143,7 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                             onSubmitEditing={
                                 firstNameInput.length > 0 && lastNameInput.length > 0 ? props.onSubmit : undefined
                             }
+                            maxLength={lastNameLengthLimit}
                         />
                         {props.children}
                     </View>

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1328,10 +1328,10 @@
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.2.tgz#fb00503df6557b66c3d91d43c9101e614c35d2ec"
   integrity sha512-/3cLBoTjZs3kV1ATPA/Sp0tsL7XmlV/b8HW/qt0jqR/uP5+cdXL2YIhMXQngLRa7PhpSkEiRIYK5sl0rKsXTUg==
 
-"@pxblue/react-auth-shared@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.2.0.tgz#89c3caed88fd061180a773dc12208dc33d15cc45"
-  integrity sha512-5ydw4VjdEj/1L3Yfve2fOEAXwtgdyTnV/9LfGokKyOlya8bl4nldiiAirGmHP3wa65wmFq3L6Pa8yf0gqSIr/A==
+"@pxblue/react-auth-shared@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.4.0.tgz#cfa80ed761e22ec8109b166dd53d6e0e35c47b51"
+  integrity sha512-O9iCUW2NpxcAs9RJmlQwXdnvFIMzjN+OXhqbE0b+cleIJugHs4rV/8Zm1UneT8PyK6zsEeMwdI+SFG3F2j19UQ==
 
 "@pxblue/react-native-components@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2285, #83, and #90.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Allow users to go back during all steps in the account registration workflows
- Changed EULA page order so it shows first during self registration
- Add ability to customize character limits for first and last name text fields
- Clear Invalid credentials error message after editing input

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:

** Use shared-auth branch `feature/add-name-character-limits` to test these.

- Custom character limit, uncomment the registrationConfig definition in the `AuthUIContextProvider` in the example project's `App.tsx` file.

- Invalid credentials error message, edit the example project's `AuthUIActions.tsx `login method to immediately return `throw new Error('LOGIN.INVALID_CREDENTIALS');`. Start up example project and try to login. The "Invalid credentials" error should display on the email and password inputs. Modify either input and observe the error being removed until submitting and receiving another transit error.
