### PR TITLE
Feature/cleanup mounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             yarn prettier:check
       - run:
           name: Set Max Memory
-          command: NODE_OPTIONS=--max_old_space_size=4096
+          command: NODE_OPTIONS=--max_old_space_size=2048
       - run:
           name: Lint
           command: |

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -500,7 +500,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
+  FBReactNativeSpec: f508f3f94b5857b91f8b365481bbbffd6a0ac202
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489

--- a/login-workflow/example/package.json
+++ b/login-workflow/example/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@pxblue/colors": "^3.0.0",
         "@pxblue/icons-svg": "^1.2.0",
-        "@pxblue/react-native-auth-workflow": "^3.2.0-beta.1",
+        "@pxblue/react-native-auth-workflow": "^3.3.0",
         "@pxblue/react-native-components": "^5.0.0",
         "@pxblue/react-native-themes": "^5.1.0",
         "@react-native-async-storage/async-storage": "^1.14.1",

--- a/login-workflow/example/yarn.lock
+++ b/login-workflow/example/yarn.lock
@@ -1009,17 +1009,17 @@
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.3.tgz#285b9ba346f714d397ef4a59579443b95a77e63e"
   integrity sha512-x9SDup4pf5H54r/stZBXz7/XlMcIqnwHkEJ+9pyXVtGyQljI28lDGQCWQj6heipWAett50yx0RB3P2+MWZDhJA==
 
-"@pxblue/react-auth-shared@^3.2.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.3.0.tgz#9b3d8ada559d149d199a00710503eec9c1149bdb"
-  integrity sha512-lSGgTnETlmI+74888LNTo/wqPZL/Y13aIEXoGhzWyZJGbOOnRTycbtJFSzeNNddZPGTp5lhfyZ+D7gXtJYN5FQ==
+"@pxblue/react-auth-shared@^3.4.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.5.0.tgz#e3526c4b1962fa2a2d9ee848a7f88c013de6502b"
+  integrity sha512-cc1f8dBPuwq59dk0xmiSVwPRk7R2SAgRHeG/NaKc11/+oir5VL+rbWuZ4Y/X16ZbtPeYylRDFmDuNSOV53wjeg==
 
-"@pxblue/react-native-auth-workflow@^3.2.0-beta.1":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-native-auth-workflow/-/react-native-auth-workflow-3.2.0.tgz#15fa2069aa4e59bee457fe3e1cfd0099b29cbaee"
-  integrity sha512-KBTGAmFifvSCf/nRT6ZwH1fYzzuv+GGILQxlscQSosD2jDHJvurJXv6b1O8IVXPVnGlc0c9/JMDWBJjlaAzd0Q==
+"@pxblue/react-native-auth-workflow@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-native-auth-workflow/-/react-native-auth-workflow-3.3.0.tgz#1510c8b10345511b5dd31e0fa15df0644ed86857"
+  integrity sha512-wJKBtjE4oZIkZMBibI+sSkHr6BPVLVJpIJ6bzBihwa5NHlqgjX2E4rR1XSIYU2Zr+rOw1SYmA4ST9MFfSotVDQ==
   dependencies:
-    "@pxblue/react-auth-shared" "^3.2.0"
+    "@pxblue/react-auth-shared" "^3.4.0"
     lodash.clonedeep "^4.5.0"
     react-native-status-bar-height "^2.5.0"
 

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -81,6 +81,7 @@
         "@react-native-community/masked-view": "^0.1.7",
         "@react-navigation/native": "^5.1.1",
         "@react-navigation/stack": "^5.2.3",
+        "@testing-library/react-native": "^7.2.0",
         "@types/color": "^3.0.1",
         "@types/enzyme": "^3.10.5",
         "@types/enzyme-adapter-react-16": "^1.0.6",

--- a/login-workflow/src/__tests__/components/Components-test.tsx
+++ b/login-workflow/src/__tests__/components/Components-test.tsx
@@ -20,6 +20,7 @@ import { Spinner } from '../../components/Spinner';
 import { TextInput } from '../../components/TextInput';
 import { TextInputSecure } from '../../components/TextInputSecure';
 import { ToggleButton } from '../../components/ToggleButton';
+import { cleanup } from '@testing-library/react-native';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
@@ -32,6 +33,7 @@ jest.mock('@pxblue/react-auth-shared', () => ({
 
 // test that all components render
 describe('All components tested with enzyme', () => {
+    afterEach(cleanup);
     it('Checkbox renders correctly', () => {
         const rendered = renderer
             .create(

--- a/login-workflow/src/__tests__/screens/ContactSupport-test.tsx
+++ b/login-workflow/src/__tests__/screens/ContactSupport-test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import 'react-native';
 import { ContactSupport } from '../../screens/ContactSupport';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -18,6 +19,7 @@ const Stack = createStackNavigator();
 import { ContactParams } from '@pxblue/react-auth-shared';
 
 describe('ContactSupport screen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return (
             <NavigationContainer>

--- a/login-workflow/src/__tests__/screens/Login-test.tsx
+++ b/login-workflow/src/__tests__/screens/Login-test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import 'react-native';
 import { Login } from '../../screens/Login';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -26,6 +27,7 @@ jest.mock('@pxblue/react-auth-shared', () => ({
 }));
 
 describe('Login screen tested with enzyme', () => {
+    afterEach(cleanup);
     const act = renderer.act;
 
     function baseXML(): JSX.Element {

--- a/login-workflow/src/__tests__/subscreens/AccountDetails-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/AccountDetails-test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import 'react-native';
 import { shallow, mount } from 'enzyme';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -28,6 +29,7 @@ jest.mock('@pxblue/react-auth-shared', () => ({
 }));
 
 describe('AccountDetails subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     const act = renderer.act;
 
     function baseXML(

--- a/login-workflow/src/__tests__/subscreens/CompleteSplash-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/CompleteSplash-test.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import 'react-native';
 import { CompleteSplashScreen } from '../../subScreens/CompleteSplash';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
 describe('CompleteSplash subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return <CompleteSplashScreen boldTitle={'Some bold title'} bodyText={'Some body text'} />;
     }

--- a/login-workflow/src/__tests__/subscreens/CreateAccount-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/CreateAccount-test.tsx
@@ -7,11 +7,13 @@ import React from 'react';
 import 'react-native';
 import { shallow, mount } from 'enzyme';
 import { CreateAccount } from '../../subScreens/CreateAccount';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 import { TextInputHTMLAttributes } from '@pxblue/react-auth-shared';
 
 describe('CreateAccount subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     const act = renderer.act;
 
     function baseXML(

--- a/login-workflow/src/__tests__/subscreens/CreatePassword-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/CreatePassword-test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import 'react-native';
 import { shallow, mount } from 'enzyme';
 import { CreatePassword } from '../../subScreens/CreatePassword';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 import { TextInputHTMLAttributes } from '@pxblue/react-auth-shared';
@@ -18,6 +19,7 @@ jest.mock('@pxblue/react-auth-shared', () => ({
 }));
 
 describe('CreatePassword subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     const act = renderer.act;
 
     function baseXML(

--- a/login-workflow/src/__tests__/subscreens/Eula-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/Eula-test.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import 'react-native';
 import { mount } from 'enzyme';
 import { Eula } from '../../subScreens/Eula';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
 describe('Eula subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(
         onEulaChanged = (): void => {
             /* do nothing */

--- a/login-workflow/src/__tests__/subscreens/RegistrationComplete-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/RegistrationComplete-test.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import 'react-native';
 import { RegistrationComplete } from '../../subScreens/RegistrationComplete';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
 describe('RegistrationComplete subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return (
             <RegistrationComplete

--- a/login-workflow/src/__tests__/subscreens/ResetPassword-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/ResetPassword-test.tsx
@@ -8,6 +8,7 @@ import 'react-native';
 import { mount } from 'enzyme';
 import { ResetPassword } from '../../subScreens/ResetPassword';
 import { Provider } from 'react-native-paper';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -27,6 +28,7 @@ jest.mock('@pxblue/react-auth-shared', () => ({
 }));
 
 describe('ResetPassword subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return (
             <Provider>

--- a/login-workflow/src/__tests__/subscreens/ResetPasswordConfirm-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/ResetPasswordConfirm-test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import 'react-native';
 import { ResetPasswordConfirm } from '../../subScreens/ResetPasswordConfirm';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -36,6 +37,7 @@ jest.mock('@pxblue/react-auth-shared', () => ({
 }));
 
 describe('ResetPasswordConfirm subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return (
             <Provider>

--- a/login-workflow/src/__tests__/subscreens/ResetPasswordSent-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/ResetPasswordSent-test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import 'react-native';
 import { ResetPasswordSent } from '../../subScreens/ResetPasswordSent';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -15,6 +16,7 @@ import 'react-native-gesture-handler';
 const Stack = createStackNavigator();
 
 describe('ResetPasswordSent subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return (
             <NavigationContainer>

--- a/login-workflow/src/__tests__/subscreens/ResetPasswordSuccess-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/ResetPasswordSuccess-test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import 'react-native';
 import { ResetPasswordSuccess } from '../../subScreens/ResetPasswordSuccess';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
@@ -15,6 +16,7 @@ import 'react-native-gesture-handler';
 const Stack = createStackNavigator();
 
 describe('ResetPasswordSuccess subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     function baseXML(): JSX.Element {
         return (
             <NavigationContainer>

--- a/login-workflow/src/__tests__/subscreens/VerifyEmail-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/VerifyEmail-test.tsx
@@ -7,11 +7,13 @@ import React from 'react';
 import 'react-native';
 import { shallow, mount } from 'enzyme';
 import { VerifyEmail } from '../../subScreens/VerifyEmail';
+import { cleanup } from '@testing-library/react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 import { TextInputHTMLAttributes } from '@pxblue/react-auth-shared';
 
 describe('VerifyEmail subScreen tested with enzyme', () => {
+    afterEach(cleanup);
     const act = renderer.act;
 
     function baseXML(

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1285,6 +1285,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -1557,6 +1568,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/react-native@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.2.0.tgz#e5ec5b0974e4e5f525f8057563417d1e9f820d96"
+  integrity sha512-rDKzJjAAeGgyoJT0gFQiMsIL09chdWcwZyYx6WZHMgm2c5NDqY52hUuyTkzhqddMYWmSRklFphSg7B2HX+246Q==
+  dependencies:
+    pretty-format "^26.0.1"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -1674,6 +1692,13 @@
   integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
+  integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
+  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^24.0.0":
@@ -7203,6 +7228,16 @@ pretty-format@^25.1.0, pretty-format@^25.2.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.1:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -7351,6 +7386,11 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0, react
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-native-animatable@1.3.3:
   version "1.3.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- add @testing-library/react-native and use cleanup() within tests
- upgrade to latest of @pxblue/react-native-auth-workflow
- set ci memory to max_old_space_size=2048

Build times consistent right now but I still have build log errors after upgrading to 3.0.0 of rn-auth-workflow
![image](https://user-images.githubusercontent.com/37150565/131562020-6096f831-eea5-4d33-b320-ca6446facd30.png)

[build log](https://app.circleci.com/pipelines/github/pxblue/react-native-workflows/254/workflows/1d75138a-901c-43d5-ba02-53fa0eac7a8c/jobs/322/parallel-runs/0/steps/0-109) passed but hangs during build.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
local test times decreased slightly
before:
![image](https://user-images.githubusercontent.com/37150565/131561553-86fffa7e-0eee-40b6-aea2-9d2b0dc95f68.png)

After:
![image](https://user-images.githubusercontent.com/37150565/131561612-148c0436-4c00-4164-a45b-65a7d357e7ba.png)



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- checkout branch
- install
- yarn test
